### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,11 +12,11 @@ ClosedCube_LPS25HB	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ##################################################################
 
-begin KEYWORD2
-whoAmI KEYWORD2
+begin	KEYWORD2
+whoAmI	KEYWORD2
 
-readTemperature KEYWORD2
-readPressure KEYWORD2
+readTemperature	KEYWORD2
+readPressure	KEYWORD2
 
-readT KEYWORD2
-readP KEYWORD2
+readT	KEYWORD2
+readP	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords